### PR TITLE
Fix for issue #23

### DIFF
--- a/MicroLite.Tests/Configuration/ConfigureTests.cs
+++ b/MicroLite.Tests/Configuration/ConfigureTests.cs
@@ -19,7 +19,7 @@
         {
             var sessionFactory = Configure.Fluently().ForConnection("SqlConnection").CreateSessionFactory();
 
-            Assert.AreEqual("System.Data.SqlClient", sessionFactory.ConnectionName);
+            Assert.AreEqual("SqlConnection", sessionFactory.ConnectionName);
         }
 
         [Test]

--- a/MicroLite/Configuration/Configure.cs
+++ b/MicroLite/Configuration/Configure.cs
@@ -106,7 +106,7 @@ namespace MicroLite.Configuration
 
             try
             {
-                this.options.ConnectionName = configSection.ProviderName;
+                this.options.ConnectionName = configSection.Name;
                 this.options.ConnectionString = configSection.ConnectionString;
                 this.options.ProviderFactory = DbProviderFactories.GetFactory(configSection.ProviderName);
                 return this;

--- a/MicroLite/Core/SessionFactory.cs
+++ b/MicroLite/Core/SessionFactory.cs
@@ -18,7 +18,7 @@ namespace MicroLite.Core
     /// <summary>
     /// The default implementation of <see cref="ISessionFactory"/>.
     /// </summary>
-    [System.Diagnostics.DebuggerDisplay("SessionFactory for {ConnectionString}")]
+    [System.Diagnostics.DebuggerDisplay("SessionFactory for {ConnectionName}")]
     internal sealed class SessionFactory : ISessionFactory
     {
         private static readonly ILog log = LogManager.GetLog("MicroLite.SessionFactory");


### PR DESCRIPTION
sessionFactory.ConnectionName was returning the connection strings
provider name, which is a bit silly and breaks the MvcExtentions.
