### PR TITLE
Fixing pluralization regular expression

### DIFF
--- a/MicroLite.Tests/Mapping/Inflection/EnglishInflectionServiceTests.cs
+++ b/MicroLite.Tests/Mapping/Inflection/EnglishInflectionServiceTests.cs
@@ -23,6 +23,13 @@
         }
 
         [Fact]
+        public void ShouldNotMutilateWordsHavingFInTheMiddle()
+        {
+            var inflectionService = new EnglishInflectionService();
+            Assert.Equal("Refunds", inflectionService.ToPlural("Refund"));
+        }
+
+        [Fact]
         public void CorrectlyChangesSpecialCases()
         {
             var inflectionService = new EnglishInflectionService();

--- a/MicroLite/Mapping/Inflection/EnglishInflectionService.cs
+++ b/MicroLite/Mapping/Inflection/EnglishInflectionService.cs
@@ -27,7 +27,7 @@ namespace MicroLite.Mapping.Inflection
         {
             { "Person", "People" },
             { "Child", "Children" },
-            { "(.*)fe?", "$1ves" },
+            { "(.*)fe?$", "$1ves" },
             { "(.*)man$", "$1men" },
             { "(.+[aeiou]y)$", "$1s" },
             { "(.+[^aeiou])y$", "$1ies" },


### PR DESCRIPTION
Before this fix, the last F letter in the word was replaced with "ves",
even if it is not the very last letter.