### PR TITLE
Adds additional validation to object info set identifier value and resolves #428 bug

### DIFF
--- a/MicroLite.Tests/Mapping/ConventionMappingSettingsTests.cs
+++ b/MicroLite.Tests/Mapping/ConventionMappingSettingsTests.cs
@@ -1,4 +1,6 @@
-﻿namespace MicroLite.Tests.Mapping
+﻿using System.Runtime.InteropServices;
+
+namespace MicroLite.Tests.Mapping
 {
     using System.Data;
     using MicroLite.Mapping;
@@ -79,6 +81,14 @@
             public void ResolveTableNameReturnsPluralTypeName()
             {
                 var type = typeof(Customer);
+
+                Assert.Equal("Customers", this.settings.ResolveTableName(type));
+            }
+
+            [Fact]
+            public void ResolveTableNameWhenTypeIsGenericReturnsPluralTypeName()
+            {
+                var type = typeof(Customer<int>);
 
                 Assert.Equal("Customers", this.settings.ResolveTableName(type));
             }
@@ -169,5 +179,10 @@
                 Assert.True(this.settings.UsePluralClassNameForTableName);
             }
         }
+    }
+
+    public class Customer<T>
+    {
+        
     }
 }

--- a/MicroLite.Tests/Mapping/PocoObjectInfoTests.cs
+++ b/MicroLite.Tests/Mapping/PocoObjectInfoTests.cs
@@ -584,6 +584,56 @@
         }
 
         [Fact]
+        public void SetIdentifierValue_ThrowsArgumentNullException_IfInstanceIsNull()
+        {
+            var objectInfo = ObjectInfo.For(typeof(Customer));
+
+            var exception = Assert.Throws<ArgumentNullException>(
+                () => objectInfo.SetIdentifierValue(null, 122323));
+
+            Assert.Equal("instance", exception.ParamName);
+        }
+
+        [Fact]
+        public void SetIdentifierValue_ThrowsArgumentNullException_IfIdentifierIsNull()
+        {
+            var objectInfo = ObjectInfo.For(typeof(Customer));
+
+            var exception = Assert.Throws<ArgumentNullException>(
+                () => objectInfo.SetIdentifierValue(new Customer(), null));
+
+            Assert.Equal("identifier", exception.ParamName);
+        }
+
+        [Fact]
+        public void SetIdentifierValue_ThrowsMappingException_IfInstanceIsIncorrectType()
+        {
+            var objectInfo = ObjectInfo.For(typeof(Customer));
+
+            var exception = Assert.Throws<MappingException>(
+                () => objectInfo.SetIdentifierValue(new CustomerWithGuidIdentifier(), 122323));
+
+            Assert.Equal(
+                string.Format(ExceptionMessages.PocoObjectInfo_TypeMismatch, typeof(CustomerWithGuidIdentifier).Name, objectInfo.ForType.Name),
+                exception.Message);
+        }
+
+        [Fact]
+        public void SetIdentifierValueThrowsMicroLiteException_WhenNoIdentifierMapped()
+        {
+            ObjectInfo.MappingConvention = new ConventionMappingConvention(
+                UnitTest.GetConventionMappingSettings(IdentifierStrategy.DbGenerated));
+
+            var customer = new CustomerWithNoIdentifier();
+
+            var objectInfo = ObjectInfo.For(typeof(CustomerWithNoIdentifier));
+
+            var exception = Assert.Throws<MicroLiteException>(() => objectInfo.SetIdentifierValue(customer, 122323));
+
+            Assert.Equal(ExceptionMessages.PocoObjectInfo_NoIdentifierColumn.FormatWith("Sales", "CustomerWithNoIdentifiers"), exception.Message);
+        }
+
+        [Fact]
         public void VerifyInstanceForInsertDoesNotThrowMicroLiteException_WhenIdentifierStrategyAssigned_AndIdentifierSet()
         {
             ObjectInfo.MappingConvention = new ConventionMappingConvention(

--- a/MicroLite.Tests/Mapping/PocoObjectInfoTests.cs
+++ b/MicroLite.Tests/Mapping/PocoObjectInfoTests.cs
@@ -599,10 +599,8 @@
         {
             var objectInfo = ObjectInfo.For(typeof(Customer));
 
-            var exception = Assert.Throws<ArgumentNullException>(
+            Assert.Throws<NullReferenceException>(
                 () => objectInfo.SetIdentifierValue(new Customer(), null));
-
-            Assert.Equal("identifier", exception.ParamName);
         }
 
         [Fact]

--- a/MicroLite.Tests/Mapping/PocoObjectInfoTests.cs
+++ b/MicroLite.Tests/Mapping/PocoObjectInfoTests.cs
@@ -595,7 +595,7 @@
         }
 
         [Fact]
-        public void SetIdentifierValue_ThrowsArgumentNullException_IfIdentifierIsNull()
+        public void SetIdentifierValue_ThrowsNullReferenceException_IfIdentifierIsNull()
         {
             var objectInfo = ObjectInfo.For(typeof(Customer));
 

--- a/MicroLite/Mapping/ConventionMappingSettings.cs
+++ b/MicroLite/Mapping/ConventionMappingSettings.cs
@@ -52,7 +52,8 @@ namespace MicroLite.Mapping
             this.ResolveSequenceName = (PropertyInfo propertyInfo) => null;
             this.ResolveTableName = (Type type) =>
             {
-                return this.UsePluralClassNameForTableName ? this.InflectionService.ToPlural(type.Name) : type.Name;
+                var name = !type.IsGenericType ? type.Name : type.Name.Substring(0, type.Name.IndexOf("`", StringComparison.InvariantCulture));
+                return this.UsePluralClassNameForTableName ? this.InflectionService.ToPlural(name) : name;
             };
             this.ResolveTableSchema = (Type type) => null;
             this.UsePluralClassNameForTableName = true;

--- a/MicroLite/Mapping/ConventionMappingSettings.cs
+++ b/MicroLite/Mapping/ConventionMappingSettings.cs
@@ -52,7 +52,7 @@ namespace MicroLite.Mapping
             this.ResolveSequenceName = (PropertyInfo propertyInfo) => null;
             this.ResolveTableName = (Type type) =>
             {
-                var name = !type.IsGenericType ? type.Name : type.Name.Substring(0, type.Name.IndexOf("`", StringComparison.InvariantCulture));
+                var name = !type.IsGenericType ? type.Name : type.Name.Substring(0, type.Name.IndexOf("`", StringComparison.OrdinalIgnoreCase));
                 return this.UsePluralClassNameForTableName ? this.InflectionService.ToPlural(name) : name;
             };
             this.ResolveTableSchema = (Type type) => null;

--- a/MicroLite/Mapping/PocoObjectInfo.cs
+++ b/MicroLite/Mapping/PocoObjectInfo.cs
@@ -235,11 +235,6 @@ namespace MicroLite.Mapping
         /// <exception cref="MicroLiteException">Thrown if the instance is not of the correct type.</exception>
         public void SetIdentifierValue(object instance, object identifier)
         {
-            if (identifier == null)
-            {
-                throw new ArgumentNullException("identifier");
-            }
-
             this.VerifyInstanceIsCorrectTypeForThisObjectInfo(instance);
             this.VerifyIdentifierMapped();
 

--- a/MicroLite/Mapping/PocoObjectInfo.cs
+++ b/MicroLite/Mapping/PocoObjectInfo.cs
@@ -235,7 +235,13 @@ namespace MicroLite.Mapping
         /// <exception cref="MicroLiteException">Thrown if the instance is not of the correct type.</exception>
         public void SetIdentifierValue(object instance, object identifier)
         {
+            if (identifier == null)
+            {
+                throw new ArgumentNullException("identifier");
+            }
+
             this.VerifyInstanceIsCorrectTypeForThisObjectInfo(instance);
+            this.VerifyIdentifierMapped();
 
             this.setIdentifierValue(instance, identifier);
         }


### PR DESCRIPTION
    Brings ObjectInfo.SetIdentifier inline with ObjectInfo.GetIndentifier